### PR TITLE
Fix structured cot

### DIFF
--- a/deepfabric/format_command.py
+++ b/deepfabric/format_command.py
@@ -1,5 +1,3 @@
-"""Format command implementation for DeepFabric CLI."""
-
 import click
 import yaml
 

--- a/deepfabric/generator.py
+++ b/deepfabric/generator.py
@@ -310,9 +310,17 @@ class DataSetGenerator:
 
         async def _generate(prompt: str) -> tuple[bool, dict | Exception]:
             try:
-                # Use higher of max_tokens, 4000 tokens for multi-turn conversations
+                # Use higher max_tokens for complex conversation types to prevent truncation
                 max_tokens = self.config.max_tokens
-                if self.config.conversation_type == "xlam_multi_turn":
+
+                # Structured CoT types need more tokens for reasoning traces + messages
+                if self.config.conversation_type in {
+                    "cot_structured",
+                    "cot_hybrid",
+                    "agent_cot_hybrid",
+                    "agent_cot_multi_turn",
+                    "xlam_multi_turn",
+                }:
                     max_tokens = max(max_tokens, 4000)
 
                 conversation = await self.llm_client.generate_async(

--- a/deepfabric/metrics.py
+++ b/deepfabric/metrics.py
@@ -1,10 +1,3 @@
-"""
-Simple analytics for DeepFabric using PostHog.
-
-Provides a single trace() function for anonymous usage analytics.
-All analytics can be disabled by setting ANONYMIZED_TELEMETRY=False.
-"""
-
 import contextlib
 import os
 


### PR DESCRIPTION
I updated generator.py:313-324 to automatically increase max_tokens to 4000 for conversation types that require complex structured outputs:

cot_structured
cot_hybrid
agent_cot_hybrid
agent_cot_multi_turn
xlam_multi_turn

Resolves: #359