### PR TITLE
Correct use of exclude_none to model_dump calls

### DIFF
--- a/deepfabric/dataset.py
+++ b/deepfabric/dataset.py
@@ -317,7 +317,7 @@ class Dataset:
 
                     if dump is not None:
                         formatted_dataset.samples = [
-                            getattr(sample, dump)() for sample in formatted_samples
+                            getattr(sample, dump)(exclude_none=True) for sample in formatted_samples
                         ]
                     else:
                         formatted_dataset.samples = formatted_samples

--- a/deepfabric/formatters/base.py
+++ b/deepfabric/formatters/base.py
@@ -73,7 +73,7 @@ def to_dict(obj) -> dict:
     if isinstance(obj, dict):
         return obj.copy()
     if isinstance(obj, BaseModel):
-        return obj.model_dump()
+        return obj.model_dump(exclude_none=True)
     raise TypeError(f"Cannot convert {type(obj)} to dict")
 
 

--- a/deepfabric/formatters/builtin/harmony.py
+++ b/deepfabric/formatters/builtin/harmony.py
@@ -152,7 +152,7 @@ class HarmonyFormatter(BaseFormatter):
 
         if self.output_format == "text":
             return {"text": self._messages_to_harmony_text(messages)}
-        return {"messages": [msg.model_dump() for msg in messages]}
+        return {"messages": [msg.model_dump(exclude_none=True) for msg in messages]}
 
     def _format_qa_sample(self, sample: dict[str, Any]) -> dict[str, Any]:
         """Format a Q&A sample to Harmony format."""
@@ -209,7 +209,7 @@ class HarmonyFormatter(BaseFormatter):
 
         if self.output_format == "text":
             return {"text": self._messages_to_harmony_text(messages)}
-        return {"messages": [msg.model_dump() for msg in messages]}
+        return {"messages": [msg.model_dump(exclude_none=True) for msg in messages]}
 
     def _format_generic_sample(self, sample: dict[str, Any]) -> dict[str, Any] | None:
         """Try to format any sample by detecting conversation patterns."""
@@ -300,7 +300,7 @@ class HarmonyFormatter(BaseFormatter):
 
         if self.output_format == "text":
             return {"text": self._messages_to_harmony_text(messages)}
-        return {"messages": [msg.model_dump() for msg in messages]}
+        return {"messages": [msg.model_dump(exclude_none=True) for msg in messages]}
 
     def _build_system_message(self, sample: dict[str, Any]) -> str:
         """Build the system message with optional metadata."""

--- a/deepfabric/formatters/builtin/openai.py
+++ b/deepfabric/formatters/builtin/openai.py
@@ -367,7 +367,7 @@ class OpenAISchemaFormatter(BaseFormatter):
 
     def format_conversation_sample(self, sample: ConversationSample) -> dict[str, Any]:
         """Format a ConversationSample (if needed for compatibility)."""
-        return {"messages": [msg.model_dump() for msg in sample.messages]}
+        return {"messages": [msg.model_dump(exclude_none=True) for msg in sample.messages]}
 
     def get_example_config(self) -> dict[str, Any]:
         """Return example configuration for this formatter."""

--- a/deepfabric/formatters/builtin/single_tool_call.py
+++ b/deepfabric/formatters/builtin/single_tool_call.py
@@ -314,7 +314,7 @@ class SingleToolCallFormatter(BaseFormatter):
 
     def format_conversation_sample(self, sample: ConversationSample) -> dict[str, Any]:
         """Format a conversation sample (if needed for compatibility)."""
-        return {"messages": [msg.model_dump() for msg in sample.messages]}
+        return {"messages": [msg.model_dump(exclude_none=True) for msg in sample.messages]}
 
     def get_example_config(self) -> dict[str, Any]:
         """Return example configuration for this formatter."""

--- a/deepfabric/formatters/builtin/tool_calling.py
+++ b/deepfabric/formatters/builtin/tool_calling.py
@@ -262,7 +262,7 @@ class ToolCallingFormatter(BaseFormatter):
 
     def format_conversation_sample(self, sample: ConversationSample) -> dict[str, Any]:
         """Format a conversation sample (if needed for compatibility)."""
-        return {"messages": [msg.model_dump() for msg in sample.messages]}
+        return {"messages": [msg.model_dump(exclude_none=True) for msg in sample.messages]}
 
     def get_example_config(self) -> dict[str, Any]:
         """Return example configuration for this formatter."""

--- a/deepfabric/formatters/utils.py
+++ b/deepfabric/formatters/utils.py
@@ -53,7 +53,7 @@ def extract_messages(sample: Any) -> list[dict[str, str]]:  # noqa: PLR0911
 
     # Convert Pydantic objects to dict
     if hasattr(data, "model_dump") and callable(getattr(data, "model_dump", None)):
-        data = data.model_dump()  # type: ignore[union-attr]
+        data = data.model_dump(exclude_none=True)  # type: ignore[union-attr]
 
     # Try to extract messages from common formats
     if isinstance(data, dict):
@@ -102,7 +102,7 @@ def extract_data(sample: Any) -> dict:
     if isinstance(sample, GenericSample):
         return sample.data
     if hasattr(sample, "model_dump") and callable(getattr(sample, "model_dump", None)):
-        return sample.model_dump()  # type: ignore[union-attr]
+        return sample.model_dump(exclude_none=True)  # type: ignore[union-attr]
     if isinstance(sample, dict):
         return sample
     raise ValueError(f"Cannot extract data from sample type: {type(sample)}")


### PR DESCRIPTION
Exclude null fields from formatter output by adding `exclude_none=True` to `model_dump` calls. This ensures formatters consistently omit `empty tool_calls` and `tool_call_id` fields across all code paths, whether data is processed through YAML config or CLI arguments.