### PR TITLE
Allow Unsloth FastLanguageModel within InferenceConfig

### DIFF
--- a/deepfabric/evaluation/inference.py
+++ b/deepfabric/evaluation/inference.py
@@ -26,6 +26,15 @@ class InferenceConfig(BaseModel):
         default=False,
         description="Use Unsloth for loading adapter (for adapters trained with Unsloth)",
     )
+    max_seq_length: int = Field(
+        default=2048,
+        ge=1,
+        description="Maximum sequence length for Unsloth models",
+    )
+    load_in_4bit: bool = Field(
+        default=False,
+        description="Load model in 4-bit quantization (for Unsloth)",
+    )
     temperature: float = Field(
         default=0.7,
         ge=0.0,


### PR DESCRIPTION
This makes it possible to load unsloth saved lora models direct into the evaluation framework