### PR TITLE
Account for tool schema properties that have None/null values

### DIFF
--- a/deepfabric/schemas.py
+++ b/deepfabric/schemas.py
@@ -309,6 +309,9 @@ class ToolDefinition(BaseModel):
 
         parameters = []
         for param_name, param_props in properties.items():
+            # Skip None/null property values (can occur in some tool schemas)
+            if param_props is None:
+                continue
             json_type = param_props.get("type", "string")
             df_type = type_mapping.get(json_type, "str")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepfabric"
-version = "4.3.0"
+version = "4.3.1"
 description = "Large Scale Topic based Synthetic Data Generation for LLM Fine-Tuning & Training"
 authors = [{name = "Luke Hinds", email = "luke@alwaysfurther.ai"}]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -482,7 +482,7 @@ wheels = [
 
 [[package]]
 name = "deepfabric"
-version = "4.3.0"
+version = "4.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
The from_openai method was added in  8a1ce89 and it didn't account for the possibility that tool schema properties could have None/null values. The original implementation assumed all property values would be valid dictionaries with at least a type field.