### PR TITLE
Add LLM client integration tests for OpenAI and Gemini

### DIFF
--- a/tests/integration/test_llm_client_integration.py
+++ b/tests/integration/test_llm_client_integration.py
@@ -140,4 +140,4 @@ class TestLLMClientGemini:
         result = asyncio.run(run_async())
 
         assert isinstance(result, TopicList)
-        assert len(result.subtopics) >= 2
+        assert len(result.subtopics) >= 2  # noqa: PLR2004


### PR DESCRIPTION
- Add `test_llm_client_integration.py` with 6 tests:
  - `TestLLMClientOpenAI`: basic structured output, async output, streaming
  - `TestLLMClientGemini`: basic output, async topic list, schema handling
- Gemini tests use async-only API (generate_async)
- Tests use shared fixtures from `conftest.py`