### PR TITLE
fix: add backward compatibility for available_tools in ToolContext sc…

### DIFF
--- a/deepfabric/schemas.py
+++ b/deepfabric/schemas.py
@@ -4,11 +4,12 @@ import logging
 import re
 import secrets
 import string
+import warnings
 
 from decimal import ROUND_HALF_UP, Decimal
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, BeforeValidator, Field, field_validator
+from pydantic import BaseModel, BeforeValidator, Field, field_validator, model_validator
 
 logger = logging.getLogger(__name__)
 
@@ -811,6 +812,20 @@ class ToolContext(BaseModel):
         default=None,
         description="Deprecated: Use top-level 'tools' field instead. Kept for backward compatibility.",
     )
+
+    @model_validator(mode="after")
+    def warn_on_deprecated_available_tools(self) -> "ToolContext":
+        """Warn if the deprecated `available_tools` field is used."""
+        if self.available_tools is not None:
+            warnings.warn(
+                (
+                    "'tool_context.available_tools' is deprecated and will be removed in a future version. "
+                    "Use the top-level 'tools' field in Conversation instead."
+                ),
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return self
 
     class Config:
         extra = "forbid"


### PR DESCRIPTION
…hema

The ToolContext class was rejecting datasets with the deprecated available_tools field due to extra="forbid" validation. This caused evaluation failures when loading datasets from DeepFabric Cloud that were created with the older schema format.

Added available_tools as an optional deprecated field to maintain backward compatibility while preserving the recommendation to use the top-level 'tools' field in Conversation instead.

Error fixed:
- tool_context.available_tools: Extra inputs are not permitted
- agent_context: Value error, agent_context requires tool_context to be present