### PR TITLE
Fix MCP tool validation for nullable JSON Schema types

### DIFF
--- a/deepfabric/schemas.py
+++ b/deepfabric/schemas.py
@@ -136,7 +136,7 @@ class MCPInputSchemaProperty(BaseModel):
 
     model_config = {"extra": "allow"}
 
-    type: str = Field(default="string", description="JSON Schema type")
+    type: str | list[str] = Field(default="string", description="JSON Schema type (string or array for nullable)")
     description: str = Field(default="", description="Property description")
     default: Any | None = Field(default=None, description="Default value")
 
@@ -159,7 +159,7 @@ class MCPToolDefinition(BaseModel):
     See: https://modelcontextprotocol.io/specification/2025-06-18/schema#tool
     """
 
-    model_config = {"extra": "allow"}
+    model_config = {"extra": "allow", "populate_by_name": True}
 
     name: str = Field(description="Tool name")
     description: str = Field(default="", description="Tool description")
@@ -367,7 +367,15 @@ class ToolDefinition(BaseModel):
         required_params = set(input_schema.required)
 
         for param_name, param_props in input_schema.properties.items():
-            df_type = type_mapping.get(param_props.type, "str")
+            # Handle type as either string or array (for nullable types like ["string", "null"])
+            param_type = param_props.type
+            if isinstance(param_type, list):
+                # Extract the primary type (non-null type from array)
+                primary_type = next((t for t in param_type if t != "null"), "string")
+            else:
+                primary_type = param_type
+
+            df_type = type_mapping.get(primary_type, "str")
             default_str = str(param_props.default) if param_props.default is not None else ""
 
             parameters.append(

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -7,6 +7,7 @@ This module tests:
 - Schema mixins and composition
 - Mathematical validation
 - DeepFabric Format tool call schemas
+- MCP tool definition conversion
 """
 
 import pytest
@@ -16,8 +17,10 @@ from deepfabric.schemas import (
     TOOL_CALL_ID_PATTERN,
     ChatMessage,
     Conversation,
+    MCPToolDefinition,
     ToolCall,
     ToolCallFunction,
+    ToolDefinition,
     ToolExecution,
     generate_tool_call_id,
     get_conversation_schema,
@@ -439,3 +442,168 @@ class TestToolCallFormat:
         for msg_data in data["messages"]:
             assert "tool_calls" not in msg_data
             assert "tool_call_id" not in msg_data
+
+
+class TestMCPToolConversion:
+    """Test conversion from MCP tool definitions to DeepFabric tool definitions."""
+
+    def test_mcp_tool_with_single_type(self):
+        """Test MCP tool with standard single-type properties."""
+        mcp_tool_dict = {
+            "name": "get_weather",
+            "description": "Get weather for a location",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string", "description": "City name"},
+                    "units": {"type": "string", "description": "Temperature units"},
+                },
+                "required": ["location"],
+            },
+        }
+
+        tool = ToolDefinition.from_mcp(mcp_tool_dict)
+
+        assert tool.name == "get_weather"
+        assert tool.description == "Get weather for a location"
+        assert len(tool.parameters) == 2  # noqa: PLR2004
+
+        # Check location parameter (required)
+        loc_param = next(p for p in tool.parameters if p.name == "location")
+        assert loc_param.type == "str"
+        assert loc_param.description == "City name"
+        assert loc_param.required is True
+
+        # Check units parameter (optional)
+        units_param = next(p for p in tool.parameters if p.name == "units")
+        assert units_param.type == "str"
+        assert units_param.description == "Temperature units"
+        assert units_param.required is False
+
+    def test_mcp_tool_with_nullable_types(self):
+        """Test MCP tool with nullable type arrays (DataForSEO case)."""
+        mcp_tool_dict = {
+            "name": "keywords_data_google_ads_search_volume",
+            "description": "Get search volume data",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "location_name": {
+                        "type": ["string", "null"],
+                        "description": "Location name (nullable)",
+                    },
+                    "language_code": {
+                        "type": ["string", "null"],
+                        "description": "Language code (nullable)",
+                    },
+                    "search_partners": {
+                        "type": ["boolean", "null"],
+                        "description": "Include search partners",
+                    },
+                    "date_from": {
+                        "type": ["string", "null"],
+                        "description": "Start date",
+                    },
+                },
+                "required": [],
+            },
+        }
+
+        tool = ToolDefinition.from_mcp(mcp_tool_dict)
+
+        assert tool.name == "keywords_data_google_ads_search_volume"
+        assert tool.description == "Get search volume data"
+        assert len(tool.parameters) == 4  # noqa: PLR2004
+
+        # All parameters should be optional (not in required list)
+        for param in tool.parameters:
+            assert param.required is False
+
+        # Check that nullable types are correctly parsed to primary types
+        location_param = next(p for p in tool.parameters if p.name == "location_name")
+        assert location_param.type == "str"  # Extracted from ["string", "null"]
+
+        language_param = next(p for p in tool.parameters if p.name == "language_code")
+        assert language_param.type == "str"
+
+        search_partners_param = next(p for p in tool.parameters if p.name == "search_partners")
+        assert search_partners_param.type == "bool"  # Extracted from ["boolean", "null"]
+
+    def test_mcp_tool_with_various_types(self):
+        """Test MCP tool with various JSON Schema types."""
+        mcp_tool_dict = {
+            "name": "complex_tool",
+            "description": "A tool with various types",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Name"},
+                    "age": {"type": "integer", "description": "Age"},
+                    "score": {"type": "number", "description": "Score"},
+                    "active": {"type": "boolean", "description": "Is active"},
+                    "tags": {"type": "array", "description": "Tags list"},
+                    "metadata": {"type": "object", "description": "Metadata object"},
+                },
+                "required": ["name", "age"],
+            },
+        }
+
+        tool = ToolDefinition.from_mcp(mcp_tool_dict)
+
+        assert len(tool.parameters) == 6  # noqa: PLR2004
+
+        # Check type mappings
+        name_param = next(p for p in tool.parameters if p.name == "name")
+        assert name_param.type == "str"
+        assert name_param.required is True
+
+        age_param = next(p for p in tool.parameters if p.name == "age")
+        assert age_param.type == "int"
+        assert age_param.required is True
+
+        score_param = next(p for p in tool.parameters if p.name == "score")
+        assert score_param.type == "float"
+        assert score_param.required is False
+
+        active_param = next(p for p in tool.parameters if p.name == "active")
+        assert active_param.type == "bool"
+
+        tags_param = next(p for p in tool.parameters if p.name == "tags")
+        assert tags_param.type == "list"
+
+        metadata_param = next(p for p in tool.parameters if p.name == "metadata")
+        assert metadata_param.type == "dict"
+
+    def test_mcp_tool_with_mcp_definition_instance(self):
+        """Test from_mcp with MCPToolDefinition instance instead of dict."""
+        mcp_tool = MCPToolDefinition(
+            name="test_tool",
+            description="Test",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "param1": {"type": ["string", "null"], "description": "Nullable param"}
+                },
+                "required": [],
+            },
+        )
+
+        tool = ToolDefinition.from_mcp(mcp_tool)
+
+        assert tool.name == "test_tool"
+        assert len(tool.parameters) == 1
+        assert tool.parameters[0].type == "str"
+        assert tool.parameters[0].required is False
+
+    def test_mcp_tool_without_input_schema(self):
+        """Test MCP tool with no input schema (parameterless tool)."""
+        mcp_tool_dict = {
+            "name": "no_params_tool",
+            "description": "A tool with no parameters",
+        }
+
+        tool = ToolDefinition.from_mcp(mcp_tool_dict)
+
+        assert tool.name == "no_params_tool"
+        assert tool.description == "A tool with no parameters"
+        assert len(tool.parameters) == 0


### PR DESCRIPTION
## Fix MCP tool validation for nullable JSON Schema types

### Problem

The DataForSEO MCP server returns nullable properties using JSON Schema's array-type syntax (e.g., `["string", "null"]`), which is valid per the [JSON Schema specification](https://json-schema.org/understanding-json-schema/reference/type#type-specific-keywords). However, `MCPInputSchemaProperty` only accepted single string types, causing validation errors during tool import:

Failed to convert tool 'keywords_data_google_ads_search_volume': 2 validation errors for MCPToolDefinition inputSchema.properties.location_name.type Input should be a valid string [type=string_type, input_value=['string', 'null']]


### Solution

This PR updates the MCP tool schema validation to properly handle nullable types in accordance with JSON Schema standards.

**Changes:**
- **[schemas.py:138](deepfabric/schemas.py#L138)** - Update `MCPInputSchemaProperty.type` to accept `str | list[str]` for nullable type arrays
- **[schemas.py:161](deepfabric/schemas.py#L161)** - Add `populate_by_name=True` to `MCPToolDefinition` for snake_case/camelCase compatibility
- **[schemas.py:369-376](deepfabric/schemas.py#L369-L376)** - Enhance `ToolDefinition.from_mcp()` to extract primary type from nullable arrays (e.g., `["string", "null"]` → `"string"`)
- **[test_schemas.py:447-608](tests/unit/test_schemas.py#L447-L608)** - Add comprehensive test suite for MCP tool conversion (5 new tests)

### Example

**Before** (validation error):
```python
{
  "type": ["string", "null"],  # ❌ Rejected
  "description": "Location name"
}
After (properly handled):

{
  "type": ["string", "null"],  # ✅ Extracts "string" as primary type
  "description": "Location name"
}
# Result: ToolParameter(type="str", required=False)
```

### Testing
Added 5 comprehensive tests in TestMCPToolConversion:
✅ Standard single-type properties
✅ Nullable type arrays (DataForSEO case)
✅ Various JSON Schema types (string, integer, number, boolean, array, object)
✅ MCPToolDefinition instance handling
✅ Parameterless tools (no input schema)


### Impact
- Enables compatibility with MCP servers that use nullable JSON Schema types (e.g., DataForSEO)
- Maintains backward compatibility with existing single-type schemas
- Follows JSON Schema specification standards
- Files Changed
```
deepfabric/schemas.py      |  24 +++-
tests/unit/test_schemas.py | 188 +++++++++++++++++++++++++++
2 files changed, 194 insertions(+), 18 deletions(-)
```