### PR TITLE
Deprecate support for python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ markers = [
 ]
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py311"
 line-length = 100
 
 [tool.ruff.lint]


### PR DESCRIPTION
It causes SSL/TLS issues on older Ubuntu LTS releases.