### PR TITLE
chore: rewrite issue templates and add onboarding template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,69 +1,118 @@
-name: Bug report 🐛
-description: Report a bug to help us improve
-labels: ['bug']
+name: Bug report
+description: Something isn't working as expected
+labels: ["bug", "triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this bug report!
-  - type: checkboxes
-    id: new-bug
-    attributes:
-      label: Is there an existing issue for this?
-      description: Please search to see if an issue already exists for the bug you encountered.
-      options:
-        - label: I have searched the existing issues
-          required: true
+        Thanks for taking the time to report a bug. The more detail you can give us, the faster we can fix it.
+        
+        **Remove any API keys before posting.**
+
   - type: textarea
-    id: bug-description
+    id: description
     attributes:
-      label: Description of the bug
-      description: Tell us what bug you encountered and what should have happened.
+      label: What happened?
+      description: A clear description of what went wrong.
+      placeholder: "When I run `deepfabric generate config.yaml`, it exits with..."
     validations:
       required: true
+
   - type: textarea
-    id: steps-to-reproduce
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      placeholder: "I expected a dataset to be generated at the output path specified..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
     attributes:
       label: Steps to reproduce
-      description: Steps to reproduce the behavior.
+      description: Minimal steps to reproduce. Include the exact command or config you used.
       placeholder: |
-        Please tell us how to reproduce this bug, for example:
-        1. Install dependencies with 'uv pip install -r requirements.txt'
-        2. Run the script with 'python main.py ...'
-        3. Use the following configuration options, if any
-        4. Observe the error
+        1. Create config.yaml with...
+        2. Run `deepfabric generate config.yaml`
+        3. See error
     validations:
       required: true
+
   - type: textarea
-    id: expected-behavior
+    id: config
     attributes:
-      label: Expected behavior
-      description: What should be the expected behavior.
-      placeholder: A clear and concise description of what you expected to happen.
+      label: Config file or CLI command
+      description: Paste your config.yaml or the exact CLI command you ran. Remove any API keys before posting.
+      render: yaml
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant output or logs
+      description: Paste any error messages or stack traces here.
+      render: shell
+
+  - type: input
+    id: deepfabric-version
+    attributes:
+      label: DeepFabric version
+      placeholder: "e.g. 0.3.1 — run `deepfabric info`"
     validations:
       required: true
-  - type: textarea
-    id: screenshots
+
+  - type: dropdown
+    id: provider
     attributes:
-      label: Screenshots / Logs
-      description: If applicable, add screenshots to help explain your problem.
-      placeholder: Paste your screenshots here.
-  - type: textarea
-    id: software-info
-    attributes:
-      label: Software information
-      description: |
-        Please provide the following information about your environment.
-        Run `deepfabric --version` to get the DeepFabric version.
-      value: |
-        - Operating system:
-        - Python version:
-        - DeepFabric version:
+      label: LLM provider
+      options:
+        - OpenAI
+        - Anthropic
+        - Google Gemini
+        - Ollama (local)
+        - Other (specify in additional context)
     validations:
       required: true
+
+  - type: input
+    id: model
+    attributes:
+      label: Model
+      placeholder: "e.g. gpt-4o, claude-3.5-sonnet, gemini-1.5-flash"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: dataset-type
+    attributes:
+      label: Dataset type
+      options:
+        - Basic
+        - Reasoning
+        - Agent
+        - Not applicable
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: "e.g. 3.11.4 — run `python --version`"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Other (specify in additional context)
+    validations:
+      required: true
+
   - type: textarea
-    id: additional-context
+    id: context
     attributes:
       label: Additional context
-      description: Do you want to share any additional context about this bug?
-      placeholder: Add any other context about the problem here.
+      description: Anything else that might be relevant — install method, environment (venv, conda, uv), or what you were trying to generate.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,46 +1,63 @@
-name: Feature request ⛰️
-description: Suggest an idea for this project
-labels: ['enhancement']
+name: Feature request
+description: Suggest something for DeepFabric to support or do better
+labels: ["enhancement", "triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thank you for suggesting this feature!
-  - type: checkboxes
-    id: new-feature
+        Feature requests are welcome. The more you can tell us about the use case behind the request, the better.
+
+  - type: textarea
+    id: problem
     attributes:
-      label: Is there an existing issue or pull request for this?
-      description: Please search to see if an issue or pull request already exists for the feature you desire.
+      label: What's missing or not working for you?
+      description: Describe the situation where DeepFabric falls short today.
+      placeholder: "When generating agent datasets, there's no way to..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: What would you like DeepFabric to do?
+      description: Your idea for how DeepFabric could address this — a new config option, dataset type, CLI command, output format, anything.
+      placeholder: "It would be useful if the config supported..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What have you tried instead?
+      description: Workarounds you've considered, or other tools you've looked at for this.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which area does this relate to?
       options:
-        - label: I have searched the existing issues and pull requests
-          required: true
-  - type: textarea
-    id: feature-description
+        - Dataset generation
+        - Topic graph / diversity
+        - Tool execution (Spin / VFS)
+        - Training utilities
+        - Evaluation
+        - CLI / config
+        - Output formats
+        - Provider support
+        - Other
+
+  - type: dropdown
+    id: priority-signal
     attributes:
-      label: Feature description
-      description: Is your feature request related to a problem? Please describe.
-      placeholder: A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
-    validations:
-      required: true
+      label: How is this blocking you?
+      options:
+        - It's blocking production use of DeepFabric
+        - It's slowing down my evaluation of DeepFabric
+        - It would be a nice improvement but I have a workaround
+        - Just an idea — low urgency
+
   - type: textarea
-    id: desired-solution
-    attributes:
-      label: Desired solution
-      description: Describe the solution you'd like.
-      placeholder: A clear and concise description of what you want to happen.
-    validations:
-      required: true
-  - type: textarea
-    id: alternatives-considered
-    attributes:
-      label: Alternatives considered
-      description: Describe alternatives you've considered.
-      placeholder: A clear and concise description of any alternative solutions or features you've considered.
-    validations:
-      required: true
-  - type: textarea
-    id: additional-context
+    id: context
     attributes:
       label: Additional context
-      description: Do you want to share any additional context about this feature?
-      placeholder: Add any other context about the feature here.
+      description: What you're building, the model you're training, or anything else relevant to the request.

--- a/.github/ISSUE_TEMPLATE/onboarding_issue.yml
+++ b/.github/ISSUE_TEMPLATE/onboarding_issue.yml
@@ -1,0 +1,99 @@
+name: Onboarding / setup issue
+description: You couldn't get DeepFabric installed or running for the first time
+labels: ["onboarding", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Couldn't get DeepFabric working? We want to know about it — these reports directly improve the setup experience for everyone.
+
+        If you hit an error after DeepFabric was already working, use the **Bug report** template instead.
+
+  - type: dropdown
+    id: stage
+    attributes:
+      label: Where did you get stuck?
+      description: Pick the furthest step you reached before things went wrong.
+      options:
+        - Installation (`pip install deepfabric` or `uv add deepfabric`)
+        - Provider / API key setup
+        - First `deepfabric generate` command
+        - Writing a config file
+        - Dataset generated but output looks wrong
+        - Something else (describe below)
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you try and what went wrong?
+      placeholder: "I followed the quickstart and ran `deepfabric generate` but got..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: output
+    attributes:
+      label: Error message or output
+      description: Paste the exact error or output you saw.
+      render: shell
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: How did you install DeepFabric?
+      options:
+        - pip install deepfabric
+        - uv add deepfabric
+        - pip install "deepfabric[training]"
+        - Cloned from GitHub and uv sync
+        - Other (specify below)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: provider
+    attributes:
+      label: LLM provider you were trying to use
+      options:
+        - OpenAI
+        - Anthropic
+        - Google Gemini
+        - Ollama (local)
+        - Other (specify in additional context)
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: "e.g. 3.11.4 — run `python --version`"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Other (specify in additional context)
+    validations:
+      required: true
+
+  - type: textarea
+    id: docs-used
+    attributes:
+      label: What documentation or guide were you following?
+      placeholder: "https://docs.deepfabric.dev/..."
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else?
+      description: Environment details (venv, conda, uv), what you were trying to generate, or any other relevant context.


### PR DESCRIPTION
## Summary
- **Bug report**: restructured with structured dropdowns (provider, OS, dataset type), dedicated version/model inputs, config paste field, and API key safety reminder
- **Feature request**: clearer field labels, area dropdown (generation, CLI, evaluation, etc.), priority signal dropdown, alternatives no longer required
- **Onboarding issue** (new): template for first-time setup problems — captures install method, setup stage, and docs followed

All templates now use `triage` label and remove the "searched existing issues" checkbox.

## Test plan
- [ ] Verify templates render correctly on the upstream repo's issue creation page
- [ ] Confirm dropdowns and required fields behave as expected