### PR TITLE
chore(repo): update github organization namespace

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,7 +21,7 @@ jobs:
 
     services:
       spin:
-        image: ghcr.io/always-further/deepfabric/tools-sdk:latest
+        image: ghcr.io/nolabs-ai/deepfabric/tools-sdk:latest
         ports:
           - 3000:3000
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 ## Contributing
 
-Thank you for considering contributing to [deepfabric](https://github.com/always-further/deepfabric)!
+Thank you for considering contributing to [deepfabric](https://github.com/nolabs-ai/deepfabric)!
 
-When contributing, please first discuss the change you wish to make via [issue](https://github.com/always-further/deepfabric/issues), [email](mailto:hello@alwaysfurther.ai), or any other method with the owners of this repository before making a change.
+When contributing, please first discuss the change you wish to make via [issue](https://github.com/nolabs-ai/deepfabric/issues), [email](mailto:hello@alwaysfurther.ai), or any other method with the owners of this repository before making a change.
 
 Note that we have a [Code of Conduct](./CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
   <!-- CTA Buttons -->
   <p>
-    <a href="https://github.com/always-further/deepfabric/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
+    <a href="https://github.com/nolabs-ai/deepfabric/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
       <img src="https://img.shields.io/badge/Contribute-Good%20First%20Issues-green?style=for-the-badge&logo=github" alt="Good First Issues"/>
     </a>
     &nbsp;
@@ -21,8 +21,8 @@
     <a href="https://opensource.org/licenses/Apache-2.0">
       <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License"/>
     </a>
-    <a href="https://github.com/always-further/deepfabric/actions/workflows/test.yml">
-      <img src="https://github.com/always-further/deepfabric/actions/workflows/test.yml/badge.svg" alt="CI Status"/>
+    <a href="https://github.com/nolabs-ai/deepfabric/actions/workflows/test.yml">
+      <img src="https://github.com/nolabs-ai/deepfabric/actions/workflows/test.yml/badge.svg" alt="CI Status"/>
     </a>
     <a href="https://pypi.org/project/deepfabric/">
       <img src="https://img.shields.io/pypi/v/deepfabric.svg" alt="PyPI Version"/>
@@ -84,7 +84,7 @@ DeepFabric also uses YAML configuration with three main sections and optional sh
 > [!NOTE]  
 > The following uses mocked tool execution, so will require a runing Spin service, which we provide in a docker image:
 ```bash
-docker run -d -p 3000:3000 ghcr.io/always-further/deepfabric/tools-sdk:latest`
+docker run -d -p 3000:3000 ghcr.io/nolabs-ai/deepfabric/tools-sdk:latest`
 ```
 
 Save the following as `config.yaml`:
@@ -537,16 +537,16 @@ You can extend DeepFabric with custom tools written in Python, JavaScript, Go, o
 
 ## Resources
 
-- [Documentation](https://always-further.github.io/deepfabric/)
+- [Documentation](https://nolabs-ai.github.io/deepfabric/)
 - [Examples](./examples/README.md)
 - [Tool Tracing Guide](./tool-traces.md)
 - [Discord](https://discord.gg/pPcjYzGvbS)
-- [Issues](https://github.com/always-further/deepfabric/issues)
+- [Issues](https://github.com/nolabs-ai/deepfabric/issues)
 
 ## Development
 
 ```bash
-git clone https://github.com/always-further/deepfabric
+git clone https://github.com/nolabs-ai/deepfabric
 cd deepfabric
 uv sync --all-extras
 make test

--- a/deepfabric/cli.py
+++ b/deepfabric/cli.py
@@ -1493,7 +1493,7 @@ def info() -> None:
             tui.console.print(f"  [yellow]{var}[/yellow] - {desc}")
 
         tui.console.print(
-            "\nFor more information, visit: [link]https://github.com/always-further/deepfabric[/link]"
+            "\nFor more information, visit: [link]https://github.com/nolabs-ai/deepfabric[/link]"
         )
 
     except Exception as e:

--- a/docs/dataset-generation/agent.md
+++ b/docs/dataset-generation/agent.md
@@ -6,7 +6,7 @@ Agent datasets train models to use tools. DeepFabric uses single-turn agent mode
     Agent datasets require the Spin tool service. See [Tools](../tools/index.md) for setup, or just use Docker:
 
     ```bash
-    docker run -d -p 3000:3000 ghcr.io/always-further/deepfabric/tools-sdk:latest
+    docker run -d -p 3000:3000 ghcr.io/nolabs-ai/deepfabric/tools-sdk:latest
     ```
 
 ## When to Use

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ hide:
   <h3>Focused Training for more Grounded and Efficient Models</h3>
 
   <p>
-    <a href="https://github.com/always-further/deepfabric/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
+    <a href="https://github.com/nolabs-ai/deepfabric/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
       <img src="https://img.shields.io/badge/Contribute-Good%20First%20Issues-green?style=for-the-badge&logo=github" alt="Good First Issues"/>
     </a>
     &nbsp;
@@ -76,7 +76,7 @@ If you plan to use the training or evaluation utilities described in the [Traini
 === "Development"
 
     ```bash
-    git clone https://github.com/always-further/deepfabric.git
+    git clone https://github.com/nolabs-ai/deepfabric.git
     cd deepfabric
     uv sync --all-extras
     ```

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -65,7 +65,7 @@ Components are WebAssembly modules that handle specific tool categories:
     We provide a prepacked Docker image:
 
     ```bash
-    docker run -d -p 3000:3000 ghcr.io/always-further/deepfabric/tools-sdk:latest
+    docker run -d -p 3000:3000 ghcr.io/nolabs-ai/deepfabric/tools-sdk:latest
     ```
 
     This will now be accessible at `http://localhost:3000`.

--- a/docs/tools/mock.md
+++ b/docs/tools/mock.md
@@ -36,7 +36,7 @@ The workflow has two phases:
 ### 1. Start Spin
 
 ```bash
-docker run -d -p 3000:3000 ghcr.io/always-further/deepfabric/tools-sdk:latest
+docker run -d -p 3000:3000 ghcr.io/nolabs-ai/deepfabric/tools-sdk:latest
 ```
 
 ### 2. Import Tools from MCP Server
@@ -356,8 +356,8 @@ done
 !!! example "Complete Examples"
     See working examples in the repository:
 
-    - [`examples/tools-sdk-examples/github/`](https://github.com/always-further/deepfabric/tree/main/examples/tools-sdk-examples/github) - GitHub tools with mock data
-    - [`examples/tools-sdk-examples/kubernetes/`](https://github.com/always-further/deepfabric/tree/main/examples/tools-sdk-examples/kubernetes) - Kubernetes tools with fixtures
+    - [`examples/tools-sdk-examples/github/`](https://github.com/nolabs-ai/deepfabric/tree/main/examples/tools-sdk-examples/github) - GitHub tools with mock data
+    - [`examples/tools-sdk-examples/kubernetes/`](https://github.com/nolabs-ai/deepfabric/tree/main/examples/tools-sdk-examples/kubernetes) - Kubernetes tools with fixtures
 
 ## API Reference
 

--- a/docs/tools/spin.md
+++ b/docs/tools/spin.md
@@ -16,13 +16,13 @@ There are two ways to run the Spin service:
     The fastest way to get started. No installation required:
 
     ```bash
-    docker run -d -p 3000:3000 ghcr.io/always-further/deepfabric/tools-sdk:latest
+    docker run -d -p 3000:3000 ghcr.io/nolabs-ai/deepfabric/tools-sdk:latest
     ```
 
     With a custom port:
 
     ```bash
-    docker run -d -p 8080:3000 ghcr.io/always-further/deepfabric/tools-sdk:latest
+    docker run -d -p 8080:3000 ghcr.io/nolabs-ai/deepfabric/tools-sdk:latest
     ```
 
     Verify it's running:

--- a/docs/tools/vfs.md
+++ b/docs/tools/vfs.md
@@ -12,7 +12,7 @@ The Virtual Filesystem (VFS) component provides file operations in an isolated, 
 | `delete_file` | Delete a file | `file_path` (string) |
 
 !!! tip "Need another builtin tool?"
-    If you need a generic tool that would see wide use, [open an issue](https://github.com/always-further/deepfabric/issues) to request it.
+    If you need a generic tool that would see wide use, [open an issue](https://github.com/nolabs-ai/deepfabric/issues) to request it.
 
 ## Configuration
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: DeepFabric Documentation
 site_description: Synthetic Dataset Generation for Language Models
 site_url: https://deepfabric.readthedocs.io
-repo_url: https://github.com/always-further/deepfabric
-repo_name: always-further/deepfabric
+repo_url: https://github.com/nolabs-ai/deepfabric
+repo_name: nolabs-ai/deepfabric
 
 nav:
   - Home: index.md
@@ -128,7 +128,7 @@ plugins:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/always-further/deepfabric
+      link: https://github.com/nolabs-ai/deepfabric
     - icon: fontawesome/brands/python
       link: https://pypi.org/project/deepfabric/
 

--- a/notebooks/Train_and_Evaluate_Qwen3_4B_Thinking_as_a_Blender_MCP_Agent.ipynb
+++ b/notebooks/Train_and_Evaluate_Qwen3_4B_Thinking_as_a_Blender_MCP_Agent.ipynb
@@ -8,12 +8,12 @@
       "source": [
         "<center>\n",
         "<h3></h3>\n",
-        "<img src=\"https://github.com/always-further/deepfabric/raw/main/assets/logo-light-hols.png\" width=\"25%\">\n",
+        "<img src=\"https://github.com/nolabs-ai/deepfabric/raw/main/assets/logo-light-hols.png\" width=\"25%\">\n",
         "<a href=\"https://alwaysfurther.ai\"><h5>By Always Further AI</a></h5>\n",
         "<h3>Train and Evaluate Qwen3-4B-Thinking as a Blender MCP Agent</h3>\n",
         "<!-- CTA Buttons -->\n",
         "<p>\n",
-        "  <a href=\"https://github.com/always-further/deepfabric/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22\">\n",
+        "  <a href=\"https://github.com/nolabs-ai/deepfabric/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22\">\n",
         "    <img src=\"https://img.shields.io/badge/Contribute-Good%20First%20Issues-green?style=for-the-badge&logo=github\" alt=\"Good First Issues\"/>\n",
         "  </a>\n",
         "  &nbsp;\n",
@@ -26,8 +26,8 @@
         "  <a href=\"https://opensource.org/licenses/Apache-2.0\">\n",
         "    <img src=\"https://img.shields.io/badge/License-Apache%202.0-blue.svg\" alt=\"License\"/>\n",
         "  </a>\n",
-        "  <a href=\"https://github.com/always-further/deepfabric/actions/workflows/test.yml\">\n",
-        "    <img src=\"https://github.com/always-further/deepfabric/actions/workflows/test.yml/badge.svg\" alt=\"CI Status\"/>\n",
+        "  <a href=\"https://github.com/nolabs-ai/deepfabric/actions/workflows/test.yml\">\n",
+        "    <img src=\"https://github.com/nolabs-ai/deepfabric/actions/workflows/test.yml/badge.svg\" alt=\"CI Status\"/>\n",
         "  </a>\n",
         "  <a href=\"https://pypi.org/project/deepfabric/\">\n",
         "    <img src=\"https://img.shields.io/pypi/v/deepfabric.svg\" alt=\"PyPI Version\"/>\n",
@@ -67,7 +67,7 @@
         "\n",
         "DeepFabric is open source and completely unrestricted, so knock yourself out!\n",
         "\n",
-        "It really helps us know we’re providing value, so if you could ⭐ star us on [Github](https://github.com/always-further/deepfabric) ⭐ that would be ace!\n",
+        "It really helps us know we’re providing value, so if you could ⭐ star us on [Github](https://github.com/nolabs-ai/deepfabric) ⭐ that would be ace!\n",
         "\n",
         "#### **Standing on the shoulders of (un)Sloths!**\n",
         "\n",
@@ -87,7 +87,7 @@
       "source": [
         "## **Dataset Generation**\n",
         "\n",
-        "![DeepFabric Terminal Demo](https://github.com/always-further/deepfabric/blob/main/assets/df-demo.gif?raw=true)\n",
+        "![DeepFabric Terminal Demo](https://github.com/nolabs-ai/deepfabric/blob/main/assets/df-demo.gif?raw=true)\n",
         "\n",
         "Two choices available here, you can either use the existing dataset we have generated or create your own.\n",
         "\n",
@@ -97,7 +97,7 @@
         "\n",
         "1. **Run the DeepFabric tools-sdk docker image**\n",
         "\n",
-        "`docker run -d -p 3000:3000 ghcr.io/always-further/deepfabric/tools-sdk:latest`\n",
+        "`docker run -d -p 3000:3000 ghcr.io/nolabs-ai/deepfabric/tools-sdk:latest`\n",
         "\n",
         "2. **Create the mock Tools schema from the Blender MCP Workspace Server**\n",
         "\n",
@@ -2546,7 +2546,7 @@
         "\n",
         "DeepFabric is open source and completely unrestricted, so knock yourself out!\n",
         "\n",
-        "Don't forget to give us a ⭐ star us on [Github](https://github.com/always-further/deepfabric) ⭐ if this has been useful to you."
+        "Don't forget to give us a ⭐ star us on [Github](https://github.com/nolabs-ai/deepfabric) ⭐ if this has been useful to you."
       ],
       "metadata": {
         "id": "Z0d_s14-H4Of"

--- a/notebooks/dataset-compatibility-check.ipynb
+++ b/notebooks/dataset-compatibility-check.ipynb
@@ -7,11 +7,11 @@
    "source": [
     "<center>\n",
     "<h3></h3>\n",
-    "<img src=\"https://github.com/always-further/deepfabric/raw/main/assets/logo-light.png\" width=\"20%\">\n",
+    "<img src=\"https://github.com/nolabs-ai/deepfabric/raw/main/assets/logo-light.png\" width=\"20%\">\n",
     "<h3>DeepFabric Dataset Compatibility Checker</h3>\n",
     "<!-- CTA Buttons -->\n",
     "<p>\n",
-    "  <a href=\"https://github.com/always-further/deepfabric/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22\">\n",
+    "  <a href=\"https://github.com/nolabs-ai/deepfabric/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22\">\n",
     "    <img src=\"https://img.shields.io/badge/Contribute-Good%20First%20Issues-green?style=for-the-badge&logo=github\" alt=\"Good First Issues\"/>\n",
     "  </a>\n",
     "  &nbsp;\n",
@@ -24,8 +24,8 @@
     "  <a href=\"https://opensource.org/licenses/Apache-2.0\">\n",
     "    <img src=\"https://img.shields.io/badge/License-Apache%202.0-blue.svg\" alt=\"License\"/>\n",
     "  </a>\n",
-    "  <a href=\"https://github.com/always-further/deepfabric/actions/workflows/test.yml\">\n",
-    "    <img src=\"https://github.com/always-further/deepfabric/actions/workflows/test.yml/badge.svg\" alt=\"CI Status\"/>\n",
+    "  <a href=\"https://github.com/nolabs-ai/deepfabric/actions/workflows/test.yml\">\n",
+    "    <img src=\"https://github.com/nolabs-ai/deepfabric/actions/workflows/test.yml/badge.svg\" alt=\"CI Status\"/>\n",
     "  </a>\n",
     "  <a href=\"https://pypi.org/project/deepfabric/\">\n",
     "    <img src=\"https://img.shields.io/pypi/v/deepfabric.svg\" alt=\"PyPI Version\"/>\n",
@@ -47,7 +47,7 @@
    "source": [
     "Test if your DeepFabric dataset is compatible with a model's chat template.\n",
     "\n",
-    "If you need support with any issues, raise an issue on the [DeepFabric GitHub](https://github.com/always-further/deepfabric/issues/new/) or join the [DeepFabric Discord](https://discord.gg/pPcjYzGvbS)."
+    "If you need support with any issues, raise an issue on the [DeepFabric GitHub](https://github.com/nolabs-ai/deepfabric/issues/new/) or join the [DeepFabric Discord](https://discord.gg/pPcjYzGvbS)."
    ]
   },
   {

--- a/tests/integration/test_spin_integration.py
+++ b/tests/integration/test_spin_integration.py
@@ -1,7 +1,7 @@
 """Integration tests for SpinClient with real Spin service.
 
 These tests require the Spin tools-sdk container to be running:
-    docker run -d -p 3000:3000 ghcr.io/always-further/deepfabric/tools-sdk:latest
+    docker run -d -p 3000:3000 ghcr.io/nolabs-ai/deepfabric/tools-sdk:latest
 
 In CI, the container is started as a service in the GitHub Actions workflow.
 """


### PR DESCRIPTION
This commit systematically updates all occurrences of the previous GitHub organization `always-further` to `nolabs-ai` across the codebase.

Changes include:
- Repository URLs in documentation, README, and contributing guidelines.
- Docker image paths for the `tools-sdk` in CI workflows, documentation, and notebooks.
- Links in the CLI output.
- `mkdocs.yml` repository configuration.
